### PR TITLE
Add unit tests for kml module

### DIFF
--- a/src/kml/__snapshots__/appointments.spec.js.snap
+++ b/src/kml/__snapshots__/appointments.spec.js.snap
@@ -39,68 +39,46 @@ exports[`getAppointmentsKML renders KML for the retrieved list of appointments 1
     </LabelStyle>
 </Style>,
 <Placemark>
-    <name>Install - Sat, Jan 1</name>
+    <name>Install - Fri, Dec 4</name>
     <ExtendedData>
         <Data name=\\"Type\\">
     <value>Install</value>
 </Data>
         <Data name=\\"Date\\">
-    <value>Sat, Jan 1</value>
+    <value>Fri, Dec 4</value>
 </Data>
         <Data name=\\"Hour\\">
-    <value>8:00 AM</value>
+    <value>6:00 PM</value>
 </Data>
         <Data name=\\"Links\\">
-    <value><a href=\\"https://support.nycmesh.net/scp/tickets.php?a=search&amp;query=1111\\" style=\\"margin-right: 1rem;\\">Ticket →</a></value>
+    <value><a href=\\"https://support.nycmesh.net/scp/tickets.php?a=search&amp;query=1810\\" style=\\"margin-right: 1rem;\\">Ticket →</a></value>
 </Data>
     </ExtendedData>
     <Point>
         <altitudeMode>absolute</altitudeMode>
-        <coordinates>133.2211,91.1442,300</coordinates>
+        <coordinates>-73.9403011,40.7253199,25</coordinates>
     </Point>
     <styleUrl>#install</styleUrl>
 </Placemark>,
 <Placemark>
-    <name>Install - Sat, Jan 1</name>
+    <name>Install - Thu, Oct 1</name>
     <ExtendedData>
         <Data name=\\"Type\\">
     <value>Install</value>
 </Data>
         <Data name=\\"Date\\">
-    <value>Sat, Jan 1</value>
+    <value>Thu, Oct 1</value>
 </Data>
         <Data name=\\"Hour\\">
-    <value>5:28 AM</value>
+    <value>2:00 PM</value>
 </Data>
         <Data name=\\"Links\\">
-    <value><a href=\\"https://support.nycmesh.net/scp/tickets.php?a=search&amp;query=2222\\" style=\\"margin-right: 1rem;\\">Ticket →</a></value>
+    <value><a href=\\"https://support.nycmesh.net/scp/tickets.php?a=search&amp;query=1811\\" style=\\"margin-right: 1rem;\\">Ticket →</a></value>
 </Data>
     </ExtendedData>
     <Point>
         <altitudeMode>absolute</altitudeMode>
-        <coordinates>133.291,91.1423,100</coordinates>
-    </Point>
-    <styleUrl>#install</styleUrl>
-</Placemark>,
-<Placemark>
-    <name>Install - Sat, Jan 1</name>
-    <ExtendedData>
-        <Data name=\\"Type\\">
-    <value>Install</value>
-</Data>
-        <Data name=\\"Date\\">
-    <value>Sat, Jan 1</value>
-</Data>
-        <Data name=\\"Hour\\">
-    <value>10:23 AM</value>
-</Data>
-        <Data name=\\"Links\\">
-    <value><a href=\\"https://support.nycmesh.net/scp/tickets.php?a=search&amp;query=3333\\" style=\\"margin-right: 1rem;\\">Ticket →</a></value>
-</Data>
-    </ExtendedData>
-    <Point>
-        <altitudeMode>absolute</altitudeMode>
-        <coordinates>133.2401,91.1401,250</coordinates>
+        <coordinates>-73.9404138,40.7253234,21</coordinates>
     </Point>
     <styleUrl>#install</styleUrl>
 </Placemark>

--- a/src/kml/__snapshots__/appointments.spec.js.snap
+++ b/src/kml/__snapshots__/appointments.spec.js.snap
@@ -1,0 +1,109 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`getAppointmentsKML renders KML for the retrieved list of appointments 1`] = `
+"<?xml version=\\"1.0\\" encoding=\\"UTF-8\\"?>
+<kml xmlns=\\"http://www.opengis.net/kml/2.2\\">
+    <Document>
+        <Style id=\\"install\\">
+    <IconStyle>
+        <scale>0.75</scale> 
+        <Icon>
+            <href>https://i.imgur.com/4baif2L.png</href>
+        </Icon>
+        <hotSpot xunits=\\"fraction\\" yunits=\\"fraction\\" x=\\"0.5\\" y=\\"0.5\\"></hotSpot>
+    </IconStyle>
+    <LabelStyle>
+        <scale>0</scale>
+    </LabelStyle>
+</Style>,<Style id=\\"support\\">
+    <IconStyle>
+        <scale>0.75</scale> 
+        <Icon>
+            <href>https://i.imgur.com/qVRzBlS.png</href>
+        </Icon>
+        <hotSpot xunits=\\"fraction\\" yunits=\\"fraction\\" x=\\"0.5\\" y=\\"0.5\\"></hotSpot>
+    </IconStyle>
+    <LabelStyle>
+        <scale>0</scale>
+    </LabelStyle>
+</Style>,<Style id=\\"survey\\">
+    <IconStyle>
+        <scale>0.75</scale> 
+        <Icon>
+            <href>https://i.imgur.com/4baif2L.png</href>
+        </Icon>
+        <hotSpot xunits=\\"fraction\\" yunits=\\"fraction\\" x=\\"0.5\\" y=\\"0.5\\"></hotSpot>
+    </IconStyle>
+    <LabelStyle>
+        <scale>0</scale>
+    </LabelStyle>
+</Style>,
+<Placemark>
+    <name>Install - Sat, Jan 1</name>
+    <ExtendedData>
+        <Data name=\\"Type\\">
+    <value>Install</value>
+</Data>
+        <Data name=\\"Date\\">
+    <value>Sat, Jan 1</value>
+</Data>
+        <Data name=\\"Hour\\">
+    <value>8:00 AM</value>
+</Data>
+        <Data name=\\"Links\\">
+    <value><a href=\\"https://support.nycmesh.net/scp/tickets.php?a=search&amp;query=1111\\" style=\\"margin-right: 1rem;\\">Ticket →</a></value>
+</Data>
+    </ExtendedData>
+    <Point>
+        <altitudeMode>absolute</altitudeMode>
+        <coordinates>133.2211,91.1442,300</coordinates>
+    </Point>
+    <styleUrl>#install</styleUrl>
+</Placemark>,
+<Placemark>
+    <name>Install - Sat, Jan 1</name>
+    <ExtendedData>
+        <Data name=\\"Type\\">
+    <value>Install</value>
+</Data>
+        <Data name=\\"Date\\">
+    <value>Sat, Jan 1</value>
+</Data>
+        <Data name=\\"Hour\\">
+    <value>5:28 AM</value>
+</Data>
+        <Data name=\\"Links\\">
+    <value><a href=\\"https://support.nycmesh.net/scp/tickets.php?a=search&amp;query=2222\\" style=\\"margin-right: 1rem;\\">Ticket →</a></value>
+</Data>
+    </ExtendedData>
+    <Point>
+        <altitudeMode>absolute</altitudeMode>
+        <coordinates>133.291,91.1423,100</coordinates>
+    </Point>
+    <styleUrl>#install</styleUrl>
+</Placemark>,
+<Placemark>
+    <name>Install - Sat, Jan 1</name>
+    <ExtendedData>
+        <Data name=\\"Type\\">
+    <value>Install</value>
+</Data>
+        <Data name=\\"Date\\">
+    <value>Sat, Jan 1</value>
+</Data>
+        <Data name=\\"Hour\\">
+    <value>10:23 AM</value>
+</Data>
+        <Data name=\\"Links\\">
+    <value><a href=\\"https://support.nycmesh.net/scp/tickets.php?a=search&amp;query=3333\\" style=\\"margin-right: 1rem;\\">Ticket →</a></value>
+</Data>
+    </ExtendedData>
+    <Point>
+        <altitudeMode>absolute</altitudeMode>
+        <coordinates>133.2401,91.1401,250</coordinates>
+    </Point>
+    <styleUrl>#install</styleUrl>
+</Placemark>
+    </Document>
+</kml>"
+`;

--- a/src/kml/__snapshots__/index.spec.js.snap
+++ b/src/kml/__snapshots__/index.spec.js.snap
@@ -1,0 +1,35 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`getKML renders KML for appointments, LoS, nodes, and requests 1`] = `
+"<?xml version=\\"1.0\\" encoding=\\"UTF-8\\"?>
+<kml xmlns=\\"http://www.opengis.net/kml/2.2\\" xmlns:gx=\\"http://www.google.com/kml/ext/2.2\\" xmlns:kml=\\"http://www.opengis.net/kml/2.2\\" xmlns:atom=\\"http://www.w3.org/2005/Atom\\">
+<Document>
+	<name>NYC Mesh API</name>
+	<NetworkLink>
+    <name>Appointments</name>
+    <Link>
+        <href>http://localhost:9000/v1/kml/appointments</href>
+    </Link>
+</NetworkLink>
+	<NetworkLink>
+    <name>LoS</name>
+    <Link>
+        <href>http://localhost:9000/v1/kml/los</href>
+    </Link>
+</NetworkLink>
+	<NetworkLink>
+    <name>Nodes</name>
+    <Link>
+        <href>http://localhost:9000/v1/kml/nodes</href>
+    </Link>
+</NetworkLink>
+	<NetworkLink>
+    <name>Requests</name>
+    <Link>
+        <href>http://localhost:9000/v1/kml/requests</href>
+    </Link>
+</NetworkLink>
+</Document>
+</kml>
+"
+`;

--- a/src/kml/__snapshots__/los.spec.js.snap
+++ b/src/kml/__snapshots__/los.spec.js.snap
@@ -12,21 +12,12 @@ exports[`getLosKML renders KML for line-of-sight from a request to other nodes 1
     <PolyStyle>
         <color>00000000</color>
     </PolyStyle>
-</Style>,<Folder><name>5111</name>
+</Style>,<Folder><name>7059</name>
 <Placemark>
     <name>Line of Sight</name>
     <LineString>
         <altitudeMode>absolute</altitudeMode>
-        <coordinates>-74.0152093,40.645353,100m -73.9123421,40.6123248,150m</coordinates>
-    </LineString>
-    <styleUrl>#losLink</styleUrl>
-</Placemark>
-	</Folder>,<Folder><name>6111</name>
-<Placemark>
-    <name>Line of Sight</name>
-    <LineString>
-        <altitudeMode>absolute</altitudeMode>
-        <coordinates>-75.120532,39.114023,50m -73.144110,41.001234,90m</coordinates>
+        <coordinates>-74.0032029,40.7413549,95 -73.98809299999999,40.719778,72</coordinates>
     </LineString>
     <styleUrl>#losLink</styleUrl>
 </Placemark>

--- a/src/kml/__snapshots__/los.spec.js.snap
+++ b/src/kml/__snapshots__/los.spec.js.snap
@@ -1,0 +1,36 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`getLosKML renders KML for line-of-sight from a request to other nodes 1`] = `
+"<?xml version=\\"1.0\\" encoding=\\"UTF-8\\"?>
+<kml xmlns=\\"http://www.opengis.net/kml/2.2\\">
+    <Document>
+        <Style id=\\"losLink\\">
+    <LineStyle>
+        <color>7700ff00</color>
+        <width>2.5</width>
+    </LineStyle>
+    <PolyStyle>
+        <color>00000000</color>
+    </PolyStyle>
+</Style>,<Folder><name>5111</name>
+<Placemark>
+    <name>Line of Sight</name>
+    <LineString>
+        <altitudeMode>absolute</altitudeMode>
+        <coordinates>-74.0152093,40.645353,100m -73.9123421,40.6123248,150m</coordinates>
+    </LineString>
+    <styleUrl>#losLink</styleUrl>
+</Placemark>
+	</Folder>,<Folder><name>6111</name>
+<Placemark>
+    <name>Line of Sight</name>
+    <LineString>
+        <altitudeMode>absolute</altitudeMode>
+        <coordinates>-75.120532,39.114023,50m -73.144110,41.001234,90m</coordinates>
+    </LineString>
+    <styleUrl>#losLink</styleUrl>
+</Placemark>
+	</Folder>
+    </Document>
+</kml>"
+`;

--- a/src/kml/__snapshots__/nodes.spec.js.snap
+++ b/src/kml/__snapshots__/nodes.spec.js.snap
@@ -1,0 +1,216 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`getNodesKML generates KML for all the nodes 1`] = `
+"<?xml version=\\"1.0\\" encoding=\\"UTF-8\\"?>
+<kml xmlns=\\"http://www.opengis.net/kml/2.2\\">
+    <Document>
+        <Style id=\\"supernode\\">
+    <IconStyle>
+        <scale>0.6</scale> 
+        <Icon>
+            <href>https://i.imgur.com/GFd364p.png</href>
+        </Icon>
+        <hotSpot xunits=\\"fraction\\" yunits=\\"fraction\\" x=\\"0.5\\" y=\\"0.5\\"></hotSpot>
+    </IconStyle>
+    <LabelStyle>
+        <scale>0</scale>
+    </LabelStyle>
+</Style>,<Style id=\\"hub\\">
+    <IconStyle>
+        <scale>0.6</scale> 
+        <Icon>
+            <href>https://i.imgur.com/dsizT9e.png</href>
+        </Icon>
+        <hotSpot xunits=\\"fraction\\" yunits=\\"fraction\\" x=\\"0.5\\" y=\\"0.5\\"></hotSpot>
+    </IconStyle>
+    <LabelStyle>
+        <scale>0</scale>
+    </LabelStyle>
+</Style>,<Style id=\\"omni\\">
+    <IconStyle>
+        <scale>0.6</scale> 
+        <Icon>
+            <href>https://i.imgur.com/dsizT9e.png</href>
+        </Icon>
+        <hotSpot xunits=\\"fraction\\" yunits=\\"fraction\\" x=\\"0.5\\" y=\\"0.5\\"></hotSpot>
+    </IconStyle>
+    <LabelStyle>
+        <scale>0</scale>
+    </LabelStyle>
+</Style>,<Style id=\\"node\\">
+    <IconStyle>
+        <scale>0.5</scale> 
+        <Icon>
+            <href>https://i.imgur.com/OBBZi9E.png</href>
+        </Icon>
+        <hotSpot xunits=\\"fraction\\" yunits=\\"fraction\\" x=\\"0.5\\" y=\\"0.5\\"></hotSpot>
+    </IconStyle>
+    <LabelStyle>
+        <scale>0</scale>
+    </LabelStyle>
+</Style>,<Style id=\\"hubLink\\">
+    <LineStyle>
+        <color>ff00ffff</color>
+        <width>3</width>
+    </LineStyle>
+    <PolyStyle>
+        <color>00000000</color>
+    </PolyStyle>
+</Style>,<Style id=\\"backboneLink\\">
+    <LineStyle>
+        <color>ff00ffff</color>
+        <width>3</width>
+    </LineStyle>
+    <PolyStyle>
+        <color>00000000</color>
+    </PolyStyle>
+</Style>,<Style id=\\"activeLink\\">
+    <LineStyle>
+        <color>ff0000ff</color>
+        <width>3</width>
+    </LineStyle>
+    <PolyStyle>
+        <color>00000000</color>
+    </PolyStyle>
+</Style>,<Folder>
+					<name>1013</name>
+					<Placemark>
+	<name>Node 1013</name>
+		<ExtendedData>
+		
+		<Data name=\\"Status\\">
+    <value>inactive</value>
+</Data>
+		<Data name=\\"Installed\\">
+    <value>Fri Aug 15 2014</value>
+</Data>
+		<Data name=\\"Devices\\">
+    <value></value>
+</Data>
+		<Data name=\\"Notes\\">
+    <value>hub node</value>
+</Data>
+		<Data name=\\"Links\\">
+    <value><a href=\\"https://dashboard.nycmesh.net/requests/1013\\" style=\\"margin-right: 1rem;\\">Dashboard →</a> <a href=\\"https://support.nycmesh.net/scp/tickets.php?a=search&amp;query=1013\\" style=\\"margin-right: 1rem;\\">Tickets →</a></value>
+</Data>
+		<Data name=\\"Panos\\">
+    <value><img src=\\"https://imgur.com/1013/1\\" style=\\"width: 32rem; display: block;\\" /><img src=\\"https://imgur.com/1013/2\\" style=\\"width: 32rem; display: block;\\" /></value>
+</Data>
+	</ExtendedData>
+	<Point>
+		<altitudeMode>absolute</altitudeMode>
+		<coordinates>-75.934582,31.234524,122m</coordinates>
+	</Point>
+	<styleUrl>#hub</styleUrl>
+</Placemark>
+					<Placemark>
+	<name>Link</name>
+	<ExtendedData>
+		<Data name=\\"ID\\">
+    <value>92</value>
+</Data>
+		<Data name=\\"Status\\">
+    <value>inactive</value>
+</Data>
+		<Data name=\\"From\\">
+    <value>1013 Unknown Device</value>
+</Data>
+		<Data name=\\"To\\">
+    <value>Saratoga LiteAP</value>
+</Data>
+	</ExtendedData>
+	<LineString>
+		<altitudeMode>absolute</altitudeMode>
+		<coordinates>-75.934582,31.234524,122m -74.123410,33.953245,80m</coordinates>
+	</LineString>
+	<styleUrl>#activeLink</styleUrl>
+</Placemark>
+
+				</Folder>,<Folder>
+					<name>9123</name>
+					<Placemark>
+	<name>Saratoga</name>
+		<ExtendedData>
+		<Data name=\\"Name\\">
+    <value>Saratoga</value>
+</Data>
+		<Data name=\\"Status\\">
+    <value>active</value>
+</Data>
+		<Data name=\\"Installed\\">
+    <value>Mon Feb 01 2016</value>
+</Data>
+		<Data name=\\"Devices\\">
+    <value>LiteAP, AF24</value>
+</Data>
+		
+		<Data name=\\"Links\\">
+    <value><a href=\\"https://dashboard.nycmesh.net/requests/9123\\" style=\\"margin-right: 1rem;\\">Dashboard →</a> <a href=\\"https://support.nycmesh.net/scp/tickets.php?a=search&amp;query=9123\\" style=\\"margin-right: 1rem;\\">Tickets →</a></value>
+</Data>
+		<Data name=\\"Panos\\">
+    <value></value>
+</Data>
+	</ExtendedData>
+	<Point>
+		<altitudeMode>absolute</altitudeMode>
+		<coordinates>-74.123410,33.953245,80m</coordinates>
+	</Point>
+	<styleUrl>#node</styleUrl>
+</Placemark>
+					
+				</Folder>,<Folder>
+					<name>9999</name>
+					<Placemark>
+	<name>Node 9999</name>
+		<ExtendedData>
+		
+		<Data name=\\"Status\\">
+    <value>active</value>
+</Data>
+		<Data name=\\"Installed\\">
+    <value>Sat Dec 21 2019</value>
+</Data>
+		<Data name=\\"Devices\\">
+    <value>Omni, LBE</value>
+</Data>
+		
+		<Data name=\\"Links\\">
+    <value><a href=\\"https://dashboard.nycmesh.net/requests/9999\\" style=\\"margin-right: 1rem;\\">Dashboard →</a> <a href=\\"https://support.nycmesh.net/scp/tickets.php?a=search&amp;query=9999\\" style=\\"margin-right: 1rem;\\">Tickets →</a></value>
+</Data>
+		<Data name=\\"Panos\\">
+    <value><img src=\\"https://imgur.com/9999\\" style=\\"width: 32rem; display: block;\\" /></value>
+</Data>
+	</ExtendedData>
+	<Point>
+		<altitudeMode>absolute</altitudeMode>
+		<coordinates>-71.123413,33.123414,230m</coordinates>
+	</Point>
+	<styleUrl>#omni</styleUrl>
+</Placemark>
+					<Placemark>
+	<name>Link</name>
+	<ExtendedData>
+		<Data name=\\"ID\\">
+    <value>91</value>
+</Data>
+		<Data name=\\"Status\\">
+    <value>active</value>
+</Data>
+		<Data name=\\"From\\">
+    <value>9999 LBE</value>
+</Data>
+		<Data name=\\"To\\">
+    <value>Saratoga LiteAP</value>
+</Data>
+	</ExtendedData>
+	<LineString>
+		<altitudeMode>absolute</altitudeMode>
+		<coordinates>-71.123413,33.123414,230m -74.123410,33.953245,80m</coordinates>
+	</LineString>
+	<styleUrl>#activeLink</styleUrl>
+</Placemark>
+
+				</Folder>
+    </Document>
+</kml>"
+`;

--- a/src/kml/__snapshots__/nodes.spec.js.snap
+++ b/src/kml/__snapshots__/nodes.spec.js.snap
@@ -73,143 +73,37 @@ exports[`getNodesKML generates KML for all the nodes 1`] = `
         <color>00000000</color>
     </PolyStyle>
 </Style>,<Folder>
-					<name>1013</name>
+					<name>7290</name>
 					<Placemark>
-	<name>Node 1013</name>
+	<name>Node 7290</name>
 		<ExtendedData>
 		
 		<Data name=\\"Status\\">
-    <value>inactive</value>
+    <value>active</value>
 </Data>
 		<Data name=\\"Installed\\">
-    <value>Fri Aug 15 2014</value>
+    <value>Sun Nov 08 2020</value>
 </Data>
 		<Data name=\\"Devices\\">
-    <value></value>
+    <value>Omni</value>
 </Data>
 		<Data name=\\"Notes\\">
-    <value>hub node</value>
+    <value>Omni port 3</value>
 </Data>
 		<Data name=\\"Links\\">
-    <value><a href=\\"https://dashboard.nycmesh.net/requests/1013\\" style=\\"margin-right: 1rem;\\">Dashboard →</a> <a href=\\"https://support.nycmesh.net/scp/tickets.php?a=search&amp;query=1013\\" style=\\"margin-right: 1rem;\\">Tickets →</a></value>
+    <value><a href=\\"https://dashboard.nycmesh.net/requests/7290\\" style=\\"margin-right: 1rem;\\">Dashboard →</a> <a href=\\"https://support.nycmesh.net/scp/tickets.php?a=search&amp;query=7290\\" style=\\"margin-right: 1rem;\\">Tickets →</a></value>
 </Data>
 		<Data name=\\"Panos\\">
-    <value><img src=\\"https://imgur.com/1013/1\\" style=\\"width: 32rem; display: block;\\" /><img src=\\"https://imgur.com/1013/2\\" style=\\"width: 32rem; display: block;\\" /></value>
+    <value><img src=\\"https://node-db.netlify.com/panoramas/5547.jpg\\" style=\\"width: 32rem; display: block;\\" /><img src=\\"https://node-db.netlify.com/panoramas/7347.jpg\\" style=\\"width: 32rem; display: block;\\" /><img src=\\"https://node-db.netlify.com/panoramas/7347a.jpg\\" style=\\"width: 32rem; display: block;\\" /></value>
 </Data>
 	</ExtendedData>
 	<Point>
 		<altitudeMode>absolute</altitudeMode>
-		<coordinates>-75.934582,31.234524,122m</coordinates>
-	</Point>
-	<styleUrl>#hub</styleUrl>
-</Placemark>
-					<Placemark>
-	<name>Link</name>
-	<ExtendedData>
-		<Data name=\\"ID\\">
-    <value>92</value>
-</Data>
-		<Data name=\\"Status\\">
-    <value>inactive</value>
-</Data>
-		<Data name=\\"From\\">
-    <value>1013 Unknown Device</value>
-</Data>
-		<Data name=\\"To\\">
-    <value>Saratoga LiteAP</value>
-</Data>
-	</ExtendedData>
-	<LineString>
-		<altitudeMode>absolute</altitudeMode>
-		<coordinates>-75.934582,31.234524,122m -74.123410,33.953245,80m</coordinates>
-	</LineString>
-	<styleUrl>#activeLink</styleUrl>
-</Placemark>
-
-				</Folder>,<Folder>
-					<name>9123</name>
-					<Placemark>
-	<name>Saratoga</name>
-		<ExtendedData>
-		<Data name=\\"Name\\">
-    <value>Saratoga</value>
-</Data>
-		<Data name=\\"Status\\">
-    <value>active</value>
-</Data>
-		<Data name=\\"Installed\\">
-    <value>Mon Feb 01 2016</value>
-</Data>
-		<Data name=\\"Devices\\">
-    <value>LiteAP, AF24</value>
-</Data>
-		
-		<Data name=\\"Links\\">
-    <value><a href=\\"https://dashboard.nycmesh.net/requests/9123\\" style=\\"margin-right: 1rem;\\">Dashboard →</a> <a href=\\"https://support.nycmesh.net/scp/tickets.php?a=search&amp;query=9123\\" style=\\"margin-right: 1rem;\\">Tickets →</a></value>
-</Data>
-		<Data name=\\"Panos\\">
-    <value></value>
-</Data>
-	</ExtendedData>
-	<Point>
-		<altitudeMode>absolute</altitudeMode>
-		<coordinates>-74.123410,33.953245,80m</coordinates>
-	</Point>
-	<styleUrl>#node</styleUrl>
-</Placemark>
-					
-				</Folder>,<Folder>
-					<name>9999</name>
-					<Placemark>
-	<name>Node 9999</name>
-		<ExtendedData>
-		
-		<Data name=\\"Status\\">
-    <value>active</value>
-</Data>
-		<Data name=\\"Installed\\">
-    <value>Sat Dec 21 2019</value>
-</Data>
-		<Data name=\\"Devices\\">
-    <value>Omni, LBE</value>
-</Data>
-		
-		<Data name=\\"Links\\">
-    <value><a href=\\"https://dashboard.nycmesh.net/requests/9999\\" style=\\"margin-right: 1rem;\\">Dashboard →</a> <a href=\\"https://support.nycmesh.net/scp/tickets.php?a=search&amp;query=9999\\" style=\\"margin-right: 1rem;\\">Tickets →</a></value>
-</Data>
-		<Data name=\\"Panos\\">
-    <value><img src=\\"https://imgur.com/9999\\" style=\\"width: 32rem; display: block;\\" /></value>
-</Data>
-	</ExtendedData>
-	<Point>
-		<altitudeMode>absolute</altitudeMode>
-		<coordinates>-71.123413,33.123414,230m</coordinates>
+		<coordinates>-73.9945616,40.7171001,35</coordinates>
 	</Point>
 	<styleUrl>#omni</styleUrl>
 </Placemark>
-					<Placemark>
-	<name>Link</name>
-	<ExtendedData>
-		<Data name=\\"ID\\">
-    <value>91</value>
-</Data>
-		<Data name=\\"Status\\">
-    <value>active</value>
-</Data>
-		<Data name=\\"From\\">
-    <value>9999 LBE</value>
-</Data>
-		<Data name=\\"To\\">
-    <value>Saratoga LiteAP</value>
-</Data>
-	</ExtendedData>
-	<LineString>
-		<altitudeMode>absolute</altitudeMode>
-		<coordinates>-71.123413,33.123414,230m -74.123410,33.953245,80m</coordinates>
-	</LineString>
-	<styleUrl>#activeLink</styleUrl>
-</Placemark>
-
+					
 				</Folder>
     </Document>
 </kml>"

--- a/src/kml/__snapshots__/requests.spec.js.snap
+++ b/src/kml/__snapshots__/requests.spec.js.snap
@@ -1,0 +1,82 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`getRequestsKML renders KML for current install requests 1`] = `
+"<?xml version=\\"1.0\\" encoding=\\"UTF-8\\"?>
+<kml xmlns=\\"http://www.opengis.net/kml/2.2\\">
+    <Document>
+        <Style id=\\"request\\">
+    <IconStyle>
+        <scale>0.5</scale> 
+        <Icon>
+            <href>https://i.imgur.com/oVFMyJU.png</href>
+        </Icon>
+        <hotSpot xunits=\\"fraction\\" yunits=\\"fraction\\" x=\\"0.5\\" y=\\"0.5\\"></hotSpot>
+    </IconStyle>
+    <LabelStyle>
+        <scale>0</scale>
+    </LabelStyle>
+</Style>,<Style id=\\"panoRequest\\">
+    <IconStyle>
+        <scale>0.5</scale> 
+        <Icon>
+            <href>https://i.imgur.com/uj6HMxZ.png</href>
+        </Icon>
+        <hotSpot xunits=\\"fraction\\" yunits=\\"fraction\\" x=\\"0.5\\" y=\\"0.5\\"></hotSpot>
+    </IconStyle>
+    <LabelStyle>
+        <scale>0</scale>
+    </LabelStyle>
+</Style>,
+<Placemark>
+	<name>8142</name>
+	<ExtendedData>
+		<Data name=\\"ID\\">
+    <value>8142</value>
+</Data>
+		<Data name=\\"Date\\">
+    <value>Sat Nov 07 2020</value>
+</Data>
+		<Data name=\\"Roof\\">
+    <value>Yes</value>
+</Data>
+		<Data name=\\"Links\\">
+    <value><a href=\\"https://dashboard.nycmesh.net/requests/8142\\" style=\\"margin-right: 1rem;\\">Dashboard →</a> <a href=\\"https://support.nycmesh.net/scp/tickets.php?a=search&amp;query=8142\\" style=\\"margin-right: 1rem;\\">Tickets →</a></value>
+</Data>
+		<Data name=\\"Panos\\">
+    <value></value>
+</Data>
+	</ExtendedData>
+	<Point>
+		<altitudeMode>absolute</altitudeMode>
+		<coordinates>34.51423,-71.31241,50m</coordinates>
+	</Point>
+	<styleUrl>#panoRequest</styleUrl>
+</Placemark>,
+<Placemark>
+	<name>9133</name>
+	<ExtendedData>
+		<Data name=\\"ID\\">
+    <value>9133</value>
+</Data>
+		<Data name=\\"Date\\">
+    <value>Sat Nov 07 2020</value>
+</Data>
+		<Data name=\\"Roof\\">
+    <value>No</value>
+</Data>
+		<Data name=\\"Links\\">
+    <value><a href=\\"https://dashboard.nycmesh.net/requests/9133\\" style=\\"margin-right: 1rem;\\">Dashboard →</a> <a href=\\"https://support.nycmesh.net/scp/tickets.php?a=search&amp;query=9133\\" style=\\"margin-right: 1rem;\\">Tickets →</a></value>
+</Data>
+		<Data name=\\"Panos\\">
+    <value><img src=\\"https://pano.rama\\" style=\\"width: 32rem; display: block;\\" /></value>
+</Data>
+	</ExtendedData>
+	<Point>
+		<altitudeMode>absolute</altitudeMode>
+		<coordinates>34.51423,-71.31241,50m</coordinates>
+	</Point>
+	<styleUrl>#panoRequest</styleUrl>
+</Placemark>
+    </Document>
+</kml>"
+`;

--- a/src/kml/__snapshots__/requests.spec.js.snap
+++ b/src/kml/__snapshots__/requests.spec.js.snap
@@ -28,19 +28,19 @@ exports[`getRequestsKML renders KML for current install requests 1`] = `
     </LabelStyle>
 </Style>,
 <Placemark>
-	<name>8142</name>
+	<name>7059</name>
 	<ExtendedData>
 		<Data name=\\"ID\\">
-    <value>8142</value>
+    <value>7059</value>
 </Data>
 		<Data name=\\"Date\\">
-    <value>Sat Nov 07 2020</value>
+    <value>Fri Sep 18 2020</value>
 </Data>
 		<Data name=\\"Roof\\">
     <value>Yes</value>
 </Data>
 		<Data name=\\"Links\\">
-    <value><a href=\\"https://dashboard.nycmesh.net/requests/8142\\" style=\\"margin-right: 1rem;\\">Dashboard →</a> <a href=\\"https://support.nycmesh.net/scp/tickets.php?a=search&amp;query=8142\\" style=\\"margin-right: 1rem;\\">Tickets →</a></value>
+    <value><a href=\\"https://dashboard.nycmesh.net/requests/7059\\" style=\\"margin-right: 1rem;\\">Dashboard →</a> <a href=\\"https://support.nycmesh.net/scp/tickets.php?a=search&amp;query=7059\\" style=\\"margin-right: 1rem;\\">Tickets →</a></value>
 </Data>
 		<Data name=\\"Panos\\">
     <value></value>
@@ -48,34 +48,34 @@ exports[`getRequestsKML renders KML for current install requests 1`] = `
 	</ExtendedData>
 	<Point>
 		<altitudeMode>absolute</altitudeMode>
-		<coordinates>34.51423,-71.31241,50m</coordinates>
+		<coordinates>-73.9428339,40.6604126,32</coordinates>
 	</Point>
-	<styleUrl>#panoRequest</styleUrl>
+	<styleUrl>#request</styleUrl>
 </Placemark>,
 <Placemark>
-	<name>9133</name>
+	<name>7060</name>
 	<ExtendedData>
 		<Data name=\\"ID\\">
-    <value>9133</value>
+    <value>7060</value>
 </Data>
 		<Data name=\\"Date\\">
-    <value>Sat Nov 07 2020</value>
+    <value>Sun Oct 18 2020</value>
 </Data>
 		<Data name=\\"Roof\\">
     <value>No</value>
 </Data>
 		<Data name=\\"Links\\">
-    <value><a href=\\"https://dashboard.nycmesh.net/requests/9133\\" style=\\"margin-right: 1rem;\\">Dashboard →</a> <a href=\\"https://support.nycmesh.net/scp/tickets.php?a=search&amp;query=9133\\" style=\\"margin-right: 1rem;\\">Tickets →</a></value>
+    <value><a href=\\"https://dashboard.nycmesh.net/requests/7060\\" style=\\"margin-right: 1rem;\\">Dashboard →</a> <a href=\\"https://support.nycmesh.net/scp/tickets.php?a=search&amp;query=7060\\" style=\\"margin-right: 1rem;\\">Tickets →</a></value>
 </Data>
 		<Data name=\\"Panos\\">
-    <value><img src=\\"https://pano.rama\\" style=\\"width: 32rem; display: block;\\" /></value>
+    <value></value>
 </Data>
 	</ExtendedData>
 	<Point>
 		<altitudeMode>absolute</altitudeMode>
-		<coordinates>34.51423,-71.31241,50m</coordinates>
+		<coordinates>-72.9428339,41.6604126,33</coordinates>
 	</Point>
-	<styleUrl>#panoRequest</styleUrl>
+	<styleUrl>#request</styleUrl>
 </Placemark>
     </Document>
 </kml>"

--- a/src/kml/appointments.js
+++ b/src/kml/appointments.js
@@ -2,7 +2,7 @@ import { format } from "date-fns";
 import { performQuery } from "../db";
 import { iconStyle, data, kml } from "./utils";
 
-export async function getAppointmentsKML(params) {
+export async function getAppointmentsKML() {
     const appointments = await getAppointments();
     const appointmentsKML = appointments.map(appointmentKML);
 

--- a/src/kml/appointments.spec.js
+++ b/src/kml/appointments.spec.js
@@ -5,9 +5,38 @@ import { getAppointmentsKML } from "./appointments";
 describe("getAppointmentsKML", () => {
   it("renders KML for the retrieved list of appointments", async () => {
     performQuery.mockResolvedValue([
-      { type: "install", date: 946713600000, lat: 91.1442, lng: 133.2211, alt: 300, request_id: 1111 },
-      { type: "install", date: 946704500000, lat: 91.1423, lng: 133.2910, alt: 100, request_id: 2222 },
-      { type: "install", date: 946722200000, lat: 91.1401, lng: 133.2401, alt: 250, request_id: 3333 },
+      {
+        id: 1,
+        type: 'install',
+        date: new Date('2020-12-04T18:00:00.000Z'),
+        notes: null,
+        request_id: 1810,
+        member_id: 1668,
+        building_id: 1672,
+        node_id: null,
+        acuity_id: 472552065,
+        slack_ts: null,
+        address: '123 4th Street',
+        lat: 40.7253199,
+        lng: -73.9403011,
+        alt: 25,
+      },
+      {
+        id: 2,
+        type: 'install',
+        date: new Date('2020-10-01T14:00:00.000Z'),
+        notes: null,
+        request_id: 1811,
+        member_id: 1669,
+        building_id: 1673,
+        node_id: null,
+        acuity_id: 472552066,
+        slack_ts: null,
+        address: '987 6th Ave',
+        lat: 40.7253234,
+        lng: -73.9404138,
+        alt: 21,
+      },
     ]);
 
     expect(await getAppointmentsKML()).toMatchSnapshot();

--- a/src/kml/appointments.spec.js
+++ b/src/kml/appointments.spec.js
@@ -1,0 +1,15 @@
+import { performQuery } from "../db";
+jest.mock("../db");
+import { getAppointmentsKML } from "./appointments";
+
+describe("getAppointmentsKML", () => {
+  it("renders KML for the retrieved list of appointments", async () => {
+    performQuery.mockResolvedValue([
+      { type: "install", date: 946713600000, lat: 91.1442, lng: 133.2211, alt: 300, request_id: 1111 },
+      { type: "install", date: 946704500000, lat: 91.1423, lng: 133.2910, alt: 100, request_id: 2222 },
+      { type: "install", date: 946722200000, lat: 91.1401, lng: 133.2401, alt: 250, request_id: 3333 },
+    ]);
+
+    expect(await getAppointmentsKML()).toMatchSnapshot();
+  })
+});

--- a/src/kml/index.spec.js
+++ b/src/kml/index.spec.js
@@ -1,0 +1,7 @@
+import { getKML } from ".";
+
+describe("getKML", () => {
+  it("renders KML for appointments, LoS, nodes, and requests", () => {
+    expect(getKML()).toMatchSnapshot();
+  });
+});

--- a/src/kml/los.js
+++ b/src/kml/los.js
@@ -1,7 +1,7 @@
 import { performQuery } from "../db";
 import { lineStyle, kml } from "./utils";
 
-export async function getLosKML(params) {
+export async function getLosKML() {
 	const los = await getLos();
 
 	const losByRequest = los.reduce((acc, cur) => {

--- a/src/kml/los.spec.js
+++ b/src/kml/los.spec.js
@@ -1,0 +1,36 @@
+import { performQuery } from "../db";
+jest.mock("../db");
+import { getLosKML } from "./los";
+
+describe("getLosKML", () => {
+  it("renders KML for line-of-sight from a request to other nodes", async () => {
+    performQuery.mockResolvedValue([
+      {
+        requests: [ { id: 5111 } ],
+        nodes: [],
+        building_a_id: 8331,
+        building_b_id: 2034,
+        lat_a: '40.645353',
+        lng_a: '-74.0152093',
+        alt_a: '100m',
+        lat_b: '40.6123248',
+        lng_b: '-73.9123421',
+        alt_b: '150m',
+      },
+      {
+        requests: [ { id: 6111 } ],
+        nodes: [ { id: 110 } ],
+        building_a_id: 4113,
+        building_b_id: 1322,
+        lat_a: '39.114023',
+        lng_a: '-75.120532',
+        alt_a: '50m',
+        lat_b: '41.001234',
+        lng_b: '-73.144110',
+        alt_b: '90m',
+      },
+    ]);
+
+    expect(await getLosKML()).toMatchSnapshot();
+  });
+});

--- a/src/kml/los.spec.js
+++ b/src/kml/los.spec.js
@@ -6,28 +6,95 @@ describe("getLosKML", () => {
   it("renders KML for line-of-sight from a request to other nodes", async () => {
     performQuery.mockResolvedValue([
       {
-        requests: [ { id: 5111 } ],
-        nodes: [],
-        building_a_id: 8331,
-        building_b_id: 2034,
-        lat_a: '40.645353',
-        lng_a: '-74.0152093',
-        alt_a: '100m',
-        lat_b: '40.6123248',
-        lng_b: '-73.9123421',
-        alt_b: '150m',
-      },
-      {
-        requests: [ { id: 6111 } ],
-        nodes: [ { id: 110 } ],
-        building_a_id: 4113,
-        building_b_id: 1322,
-        lat_a: '39.114023',
-        lng_a: '-75.120532',
-        alt_a: '50m',
-        lat_b: '41.001234',
-        lng_b: '-73.144110',
-        alt_b: '90m',
+        id: 3,
+        building_a_id: 14,
+        building_b_id: 2231,
+        lat_a: 40.7413549,
+        lng_a: -74.0032029,
+        alt_a: 95,
+        lat_b: 40.719778,
+        lng_b: -73.98809299999999,
+        alt_b: 72,
+        requests: [
+          {
+            id: 7059,
+            status: 'open',
+            apartment: null,
+            roof_access: true,
+            date: new Date('2020-09-18T12:42:20.811Z'),
+            osticket_id: null,
+            member_id: 6087,
+            building_id: 5758,
+            building: {
+              id: 5758,
+              address: 'Redacted',
+              lat: 40.6604126,
+              lng: -73.9428339,
+              alt: 32,
+              bin: 3114902,
+              notes: null
+            },
+            panoramas: null
+          },
+        ],
+        nodes: [
+          {
+            id: 7290,
+            lat: 40.7171001,
+            lng: -73.9945616,
+            alt: 35,
+            status: 'active',
+            location: 'Redacted',
+            name: null,
+            notes: 'Omni port 3',
+            create_date: new Date('2020-11-08T05:00:00.000Z'),
+            abandon_date: null,
+            building_id: 4750,
+            member_id: 1299,
+            address: 'Redacted',
+            devices: [
+              {
+                id: 800,
+                lat: 40.7171001,
+                lng: -73.9945616,
+                alt: 35,
+                azimuth: 0,
+                status: 'active',
+                name: null,
+                ssid: null,
+                notes: null,
+                create_date: '2020-11-08T00:00:00-05:00',
+                abandon_date: null,
+                device_type_id: 1,
+                node_id: 7290
+              }
+            ],
+            device_types: [
+              { id: 1, name: 'Omni', manufacturer: null, range: 0.5, width: 360 }
+            ],
+            panoramas: [
+              {
+                id: 1869,
+                url: 'https://node-db.netlify.com/panoramas/5547.jpg',
+                date: '2020-02-29T14:04:09.779-05:00',
+                request_id: 5547
+              },
+              {
+                id: 2262,
+                url: 'https://node-db.netlify.com/panoramas/7347.jpg',
+                date: '2020-10-17T20:11:42.745-04:00',
+                request_id: 7347
+              },
+              {
+                id: 2263,
+                url: 'https://node-db.netlify.com/panoramas/7347a.jpg',
+                date: '2020-10-17T20:11:42.745-04:00',
+                request_id: 7347
+              },
+              null
+            ],
+          },
+        ],
       },
     ]);
 

--- a/src/kml/nodes.spec.js
+++ b/src/kml/nodes.spec.js
@@ -6,47 +6,60 @@ describe('getNodesKML', () => {
   it('generates KML for all the nodes', async () => {
     const nodes = [
       {
-        id: 9999,
-        status: "active",
-        create_date: new Date("2019-12-21"),
+        id: 7290,
+        lat: 40.7171001,
+        lng: -73.9945616,
+        alt: 35,
+        status: 'active',
+        location: 'Redacted',
+        name: null,
+        notes: 'Omni port 3',
+        create_date: new Date('2020-11-08T05:00:00.000Z'),
+        abandon_date: null,
+        building_id: 4750,
+        member_id: 1299,
+        address: 'Redacted',
+        devices: [
+          {
+            id: 800,
+            lat: 40.7171001,
+            lng: -73.9945616,
+            alt: 35,
+            azimuth: 0,
+            status: 'active',
+            name: null,
+            ssid: null,
+            notes: null,
+            create_date: '2020-11-08T00:00:00-05:00',
+            abandon_date: null,
+            device_type_id: 1,
+            node_id: 7290
+          }
+        ],
         device_types: [
-          { name: "Omni" },
-          { name: "LBE" },
+          { id: 1, name: 'Omni', manufacturer: null, range: 0.5, width: 360 }
         ],
         panoramas: [
-          { url: "https://imgur.com/9999" },
+          {
+            id: 1869,
+            url: 'https://node-db.netlify.com/panoramas/5547.jpg',
+            date: '2020-02-29T14:04:09.779-05:00',
+            request_id: 5547
+          },
+          {
+            id: 2262,
+            url: 'https://node-db.netlify.com/panoramas/7347.jpg',
+            date: '2020-10-17T20:11:42.745-04:00',
+            request_id: 7347
+          },
+          {
+            id: 2263,
+            url: 'https://node-db.netlify.com/panoramas/7347a.jpg',
+            date: '2020-10-17T20:11:42.745-04:00',
+            request_id: 7347
+          },
+          null
         ],
-        lat: '33.123414',
-        lng: '-71.123413',
-        alt: '230m',
-      },
-      {
-        id: 9123,
-        name: "Saratoga",
-        status: "active",
-        create_date: new Date("2016-02-01"),
-        device_types: [
-          { name: "LiteAP" },
-          { name: "AF24" },
-        ],
-        panoramas: [],
-        lat: '33.953245',
-        lng: '-74.123410',
-        alt: '80m',
-      },
-      {
-        id: 1013,
-        status: "inactive",
-        create_date: new Date("2014-08-15"),
-        device_types: [],
-        notes: "hub node",
-        panoramas: [
-          { url: "https://imgur.com/1013/1" },
-          { url: "https://imgur.com/1013/2" },
-        ],
-        lat: '31.234524',
-        lng: '-75.934582',
-        alt: '122m',
       },
     ];
 
@@ -56,20 +69,77 @@ describe('getNodesKML', () => {
     // getLinks
     performQuery.mockResolvedValueOnce([
       {
-        id: 91,
-        node_a: nodes[0],
-        node_b: nodes[1],
-        device_type_a: { name: "LBE" },
-        device_type_b: { name: "LiteAP" },
-        status: "active",
-      },
-      {
-        id: 92,
-        node_a: nodes[2],
-        node_b: nodes[1],
-        device_type_a: { name: "Unknown" },
-        device_type_b: { name: "LiteAP" },
-        status: "inactive",
+        id: 166,
+        status: 'active',
+        create_date: new Date('2019-03-30T04:00:00.000Z'),
+        device_a_id: 442,
+        device_b_id: 5,
+        device_a: {
+          id: 442,
+          lat: 40.7252828,
+          lng: -73.9884895,
+          alt: 29,
+          azimuth: 0,
+          status: 'active',
+          name: null,
+          ssid: null,
+          notes: null,
+          create_date: '2019-03-30T00:00:00-04:00',
+          abandon_date: null,
+          device_type_id: 9,
+          node_id: 3072
+        },
+        device_b: {
+          id: 5,
+          lat: 40.7111043,
+          lng: -74.00127188,
+          alt: 180,
+          azimuth: 300,
+          status: 'active',
+          name: 'SN1',
+          ssid: null,
+          notes: null,
+          create_date: '2016-11-18T00:00:00-05:00',
+          abandon_date: null,
+          device_type_id: 4,
+          node_id: 227
+        },
+        device_type_a: { id: 9, name: 'Unknown', manufacturer: null, range: 0, width: 0 },
+        device_type_b: {
+          id: 4,
+          name: 'SN1Sector2',
+          manufacturer: null,
+          range: 0.75,
+          width: 90
+        },
+        node_a: {
+          id: 3072,
+          lat: 40.7252828,
+          lng: -73.9884895,
+          alt: 29,
+          status: 'active',
+          location: 'Redacted',
+          name: null,
+          notes: null,
+          create_date: '2019-03-30T00:00:00-04:00',
+          abandon_date: null,
+          building_id: 2719,
+          member_id: 2710
+        },
+        node_b: {
+          id: 227,
+          lat: 40.7111043,
+          lng: -74.00127188,
+          alt: 180,
+          status: 'active',
+          location: '375 Pearl Street, Manhattan, New York 10038',
+          name: 'Supernode 1',
+          notes: 'Supernode 1, Sector facing North',
+          create_date: '2016-11-18T00:00:00-05:00',
+          abandon_date: null,
+          building_id: 219,
+          member_id: 213
+        },
       },
     ]);
 

--- a/src/kml/nodes.spec.js
+++ b/src/kml/nodes.spec.js
@@ -1,0 +1,78 @@
+import { performQuery } from '../db';
+jest.mock('../db');
+import { getNodesKML } from './nodes';
+
+describe('getNodesKML', () => {
+  it('generates KML for all the nodes', async () => {
+    const nodes = [
+      {
+        id: 9999,
+        status: "active",
+        create_date: new Date("2019-12-21"),
+        device_types: [
+          { name: "Omni" },
+          { name: "LBE" },
+        ],
+        panoramas: [
+          { url: "https://imgur.com/9999" },
+        ],
+        lat: '33.123414',
+        lng: '-71.123413',
+        alt: '230m',
+      },
+      {
+        id: 9123,
+        name: "Saratoga",
+        status: "active",
+        create_date: new Date("2016-02-01"),
+        device_types: [
+          { name: "LiteAP" },
+          { name: "AF24" },
+        ],
+        panoramas: [],
+        lat: '33.953245',
+        lng: '-74.123410',
+        alt: '80m',
+      },
+      {
+        id: 1013,
+        status: "inactive",
+        create_date: new Date("2014-08-15"),
+        device_types: [],
+        notes: "hub node",
+        panoramas: [
+          { url: "https://imgur.com/1013/1" },
+          { url: "https://imgur.com/1013/2" },
+        ],
+        lat: '31.234524',
+        lng: '-75.934582',
+        alt: '122m',
+      },
+    ];
+
+    // getNodes
+    performQuery.mockResolvedValueOnce(nodes);
+
+    // getLinks
+    performQuery.mockResolvedValueOnce([
+      {
+        id: 91,
+        node_a: nodes[0],
+        node_b: nodes[1],
+        device_type_a: { name: "LBE" },
+        device_type_b: { name: "LiteAP" },
+        status: "active",
+      },
+      {
+        id: 92,
+        node_a: nodes[2],
+        node_b: nodes[1],
+        device_type_a: { name: "Unknown" },
+        device_type_b: { name: "LiteAP" },
+        status: "inactive",
+      },
+    ]);
+
+    expect(await getNodesKML()).toMatchSnapshot();
+  });
+});

--- a/src/kml/requests.js
+++ b/src/kml/requests.js
@@ -1,7 +1,7 @@
 import { performQuery } from "../db";
 import { iconStyle, data, panoData, kml } from "./utils";
 
-export async function getRequestsKML(params) {
+export async function getRequestsKML() {
 	const requests = await getRequests();
 
 	const elements = [

--- a/src/kml/requests.spec.js
+++ b/src/kml/requests.spec.js
@@ -6,28 +6,44 @@ describe('getRequestsKML', () => {
   it('renders KML for current install requests', async () => {
     performQuery.mockResolvedValue([
       {
-        id: 8142,
-        building: {
-          lng: '34.51423',
-          lat: '-71.31241',
-          alt: '50m',
-        },
-        date: new Date(1604713833247),
+        id: 7059,
+        status: 'open',
+        apartment: null,
         roof_access: true,
-        panoramas: [],
+        date: new Date('2020-09-18T12:42:20.811Z'),
+        osticket_id: null,
+        member_id: 6087,
+        building_id: 5758,
+        building: {
+          id: 5758,
+          address: 'Redacted',
+          lat: 40.6604126,
+          lng: -73.9428339,
+          alt: 32,
+          bin: 3114902,
+          notes: null
+        },
+        panoramas: null
       },
       {
-        id: 9133,
-        building: {
-          lng: '34.51423',
-          lat: '-71.31241',
-          alt: '50m',
-        },
-        date: new Date(1604713833247),
+        id: 7060,
+        status: 'open',
+        apartment: null,
         roof_access: false,
-        panoramas: [
-          { url: 'https://pano.rama' }
-        ],
+        date: new Date('2020-10-18T12:42:20.811Z'),
+        osticket_id: null,
+        member_id: 6088,
+        building_id: 5759,
+        building: {
+          id: 5759,
+          address: 'Redacted',
+          lat: 41.6604126,
+          lng: -72.9428339,
+          alt: 33,
+          bin: 3114911,
+          notes: null
+        },
+        panoramas: null
       },
     ]);
 

--- a/src/kml/requests.spec.js
+++ b/src/kml/requests.spec.js
@@ -1,0 +1,36 @@
+import { performQuery } from '../db';
+jest.mock('../db');
+import { getRequestsKML } from './requests';
+
+describe('getRequestsKML', () => {
+  it('renders KML for current install requests', async () => {
+    performQuery.mockResolvedValue([
+      {
+        id: 8142,
+        building: {
+          lng: '34.51423',
+          lat: '-71.31241',
+          alt: '50m',
+        },
+        date: new Date(1604713833247),
+        roof_access: true,
+        panoramas: [],
+      },
+      {
+        id: 9133,
+        building: {
+          lng: '34.51423',
+          lat: '-71.31241',
+          alt: '50m',
+        },
+        date: new Date(1604713833247),
+        roof_access: false,
+        panoramas: [
+          { url: 'https://pano.rama' }
+        ],
+      },
+    ]);
+
+    expect(await getRequestsKML()).toMatchSnapshot()
+  });
+});


### PR DESCRIPTION
I used Jest's snapshot feature for these tests. It seemed to make sense,
since this module generates a string representation, without very much
traditional logic to test.